### PR TITLE
docs: add API reference to mkdocs using mkdocstrings

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,3 @@
+# CLI API Reference
+
+::: reqtrace.cli

--- a/docs/api/coverage.md
+++ b/docs/api/coverage.md
@@ -1,0 +1,3 @@
+# Coverage API Reference
+
+::: reqtrace.coverage

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,3 @@
+# Models API Reference
+
+::: reqtrace.models

--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -1,0 +1,3 @@
+# Parser API Reference
+
+::: reqtrace.parser

--- a/docs/api/scanner.md
+++ b/docs/api/scanner.md
@@ -1,0 +1,3 @@
+# Scanner API Reference
+
+::: reqtrace.scanner

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,3 +17,9 @@ plugins:
 
 nav:
   - Home: index.md
+  - API Reference:
+    - CLI: api/cli.md
+    - Coverage: api/coverage.md
+    - Models: api/models.md
+    - Parser: api/parser.md
+    - Scanner: api/scanner.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reqtrace"
-version = "0.2.0"
+version = "0.2.1"
 description = "A GitOps-friendly requirements tracing tool"
 readme = "README.md"
 authors = [{ name = "Philip Miesbauer" }]


### PR DESCRIPTION
This adds dedicated API reference pages for each module (cli, coverage, models, parser, scanner). This increases developer visibility into our package modules and promotes code reusability.