### PR TITLE
ci: add PyPI trusted publisher workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reqtrace"
-version = "0.3.0"
+version = "0.3.1"
 description = "A GitOps-friendly requirements tracing tool"
 readme = "README.md"
 authors = [{ name = "Philip Miesbauer" }]


### PR DESCRIPTION
Automatically publishes to PyPI on every version tag using OIDC trusted publishing. No API token secrets are needed since the GitHub account is already linked to PyPI.