### PR TITLE
Fix: Parent coverage mask

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,5 +26,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[docs]"
 
+      - name: Generate Traceability Report
+        run: reqtrace --html docs/report || true
+
       - name: Deploy MkDocs to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,3 +32,7 @@ reqtrace --reqs reqs/*.yml --src src/
 ```
 
 The tool will calculate a matrix and fail your CI pipeline if any coverage is missed!
+
+## Live Traceability Report
+You can explore the traceability data and implementation history for this project!
+👉 [**View the Interactive HTML Report**](report/index.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reqtrace"
-version = "0.4.0"
+version = "0.5.0"
 description = "A GitOps-friendly requirements tracing tool"
 readme = "README.md"
 authors = [{ name = "Philip Miesbauer" }]

--- a/reqs/core.yml
+++ b/reqs/core.yml
@@ -18,6 +18,11 @@
   derived_from: [SYS-SCAN]
   description: The system must recursively scan directories.
 
+- id: REQ-SCAN-FILE
+  title: File Traversal
+  derived_from: [REQ-SCAN-DIR]
+  description: The system must scan files in directories of type reqs.
+
 - id: REQ-CLI
   title: Command Line Interface
   derived_from: [SYS-CI]

--- a/src/reqtrace/coverage.py
+++ b/src/reqtrace/coverage.py
@@ -69,11 +69,17 @@ def _calculate_rollups(index: RequirementIndex, details: Dict[str, RequirementCo
 
         if not child_ids:
             rollup = 0
+            full_total = direct_pct
         else:
             rollup_sum = sum(min(100, compute_total(cid)) for cid in child_ids)
             rollup = rollup_sum // len(child_ids)
 
-        full_total = direct_pct + rollup
+            # If children exist, direct implementation accounts for at most 50%,
+            # and the children account for the other 50%.
+            direct_contribution = min(100, direct_pct) // 2
+            child_contribution = rollup // 2
+            full_total = direct_contribution + child_contribution
+
         computed_totals[req_id] = full_total
         details[req_id].total_percentage = full_total
         return full_total

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -71,22 +71,34 @@ def test_coverage_rollup():
     index.add(Requirement(id="P3", title="Parent 3"))
     index.add(Requirement(id="C4", title="Child 4", derived_from=["P3"]))
 
+    # P4 has direct coverage of 100% but one child with 0%. Expected rollup: 99%
+    index.add(Requirement(id="P4", title="Parent 4"))
+    index.add(Requirement(id="C5", title="Child 5", derived_from=["P4"]))
+
     traces = [
         TraceMatch(file_path="foo.py", line_number=1, req_id="C1"),
         TraceMatch(file_path="foo.py", line_number=2, req_id="C2", percentage=50),
         TraceMatch(file_path="foo.py", line_number=3, req_id="C3", percentage=150),
         TraceMatch(file_path="foo.py", line_number=4, req_id="P3", percentage=20),
         TraceMatch(file_path="foo.py", line_number=5, req_id="C4", percentage=50),
+        TraceMatch(file_path="foo.py", line_number=6, req_id="P4", percentage=100),
     ]
 
     report = calculate_coverage(index, traces)
 
     assert report.coverage_details["C1"].total_percentage == 100
     assert report.coverage_details["C2"].total_percentage == 50
-    assert report.coverage_details["P1"].total_percentage == 75
+    # P1 has 0% direct, children are (100+50)/2 = 75%. Child contribution is 75 // 2 = 37%
+    assert report.coverage_details["P1"].total_percentage == 37
 
     assert report.coverage_details["C3"].total_percentage == 150
-    assert report.coverage_details["P2"].total_percentage == 100
+    # P2 has 0% direct, children are min(100, 150) = 100%. Child contribution is 100 // 2 = 50%
+    assert report.coverage_details["P2"].total_percentage == 50
 
     assert report.coverage_details["C4"].total_percentage == 50
-    assert report.coverage_details["P3"].total_percentage == 70
+    # P3 has 20% direct. Direct contribution = 10%. Children are 50%. Child contribution = 25%. Total = 35%
+    assert report.coverage_details["P3"].total_percentage == 35
+
+    assert report.coverage_details["C5"].total_percentage == 0
+    # P4 has 100% direct. Direct contribution = 50%. Children are 0%. Child contribution = 0%. Total = 50%
+    assert report.coverage_details["P4"].total_percentage == 50


### PR DESCRIPTION
Resolves #10. Implemented the rule where if children exist, direct parent coverage counts for max 50%, and the rollup of children accounts for the other 50%.